### PR TITLE
fixed navigateToDefinition not going to correct lineNumber

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ctags-support",
   "displayName": "CTags Support",
   "description": "CTags support with navigation to definition and navigation history recored",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "publisher": "jaydenlin",
   "icon": "images/icon.png",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,13 +87,17 @@ function loadTags(tagFilePath){
             return true;
         });
         let remainingString = remainingElements.join("\t");
-        let pattern = remainingElements.join("\t").substring(remainingString.lastIndexOf("\/^")+1,remainingString.lastIndexOf("\/;\""));
+        // Strip starting (/^) and ending ($/;") characters from ctags pattern
+        let pattern = remainingElements.join("\t").substring(remainingString.lastIndexOf("\/^") + 2, remainingString.lastIndexOf("$\/;\""));
+        // Escape regex pattern and add ^ and $
+        // See: https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/3561711#3561711
+        let patternEscaped = "^" + pattern.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + "$";
         tags.push({
-            description: "", 
-            label: tagName, 
+            description: "",
+            label: tagName,
             detail: fileName,
             filePath: path.join(vscode.workspace.rootPath,fileName),
-            pattern: pattern
+            pattern: patternEscaped
         });
         lineNumber++;
     }

--- a/src/grep.js
+++ b/src/grep.js
@@ -4,12 +4,13 @@ var split = require('split')
 function find(stream, reg) {
   var lineNumber = 0,
       found = 0,
-      e = new EventEmitter();
+      e = new EventEmitter(),
+      regExp = new RegExp(reg);
   stream
   .pipe(split())
   .on('data', function (line) {
     lineNumber += 1   
-    var foundItems = new RegExp(reg).exec(line);        
+    var foundItems = regExp.exec(line);        
         if (foundItems && foundItems.length > 0 && foundItems[0] !== '') {
           var item=foundItems[0];//Only use the first found
           e.emit('found', item, lineNumber);


### PR DESCRIPTION
Hi @jaydenlin,

Thanks for your vscode extension!  I was hoping to use it with ctags created on R files.  Unfortunately, Ctrl+T wasn't working to navigate to the correct line number for R functions.  I diagnosed the problem to be with the regex pattern and the fact that special characters weren't being escaped.

R functions usually follow the form:

`function_name <- function(x, y, z) {`

And so need to be escaped to:

`function_name <\- funciton\(x, y, z\) \{`

I've implemented escaping of the regex using [bobince's answer on StackOverflow](https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/3561711#3561711).

Hope it helps others.